### PR TITLE
Test Harness Gnd dist fixes

### DIFF
--- a/code/main_closed_loop_float.cpp
+++ b/code/main_closed_loop_float.cpp
@@ -876,7 +876,7 @@ void readDistData()
             distMsec = temp[0];
         }
     }
-    if (distMsec > lastDistMsec)
+    if (distMsec > lastDistMsec && distValid)
     {
         lastDistMsec = distMsec;
         newDistData = true;


### PR DESCRIPTION
@LorenzMeier:
- 341c5b2ec6742ddd3a08e6b303f7351d98d58276 makes the filter only use valid data, this is consistent with this onboard check: https://github.com/PX4/Firmware/blob/fwlandingterrain/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp#L1154 Due to this changes the test harness seems now to use the laser (--> update the ground estimate) at the same moments as the onboard version.
- da79e1d271fd6a629e94145218ba6dc077247a84: makes the ground estimate calculated from the laser (which we plot for comparison only) look the same as onboard. The raw sensor value is used independent of the valid flags.
