### PR TITLE
FILE handles are properly checked for nullptr, instead of checked against integer

### DIFF
--- a/code/main_closed_loop_float.cpp
+++ b/code/main_closed_loop_float.cpp
@@ -518,7 +518,7 @@ int main(int argc, char *argv[])
                 }
                 calcposNED(posNED, _ekf->gpsLat, _ekf->gpsLon, _ekf->gpsHgt, _ekf->latRef, _ekf->lonRef, _ekf->hgtRef);
 
-                if (pOnboardFile > 0) {
+                if (pOnboardFile != nullptr) {
                     calcposNED(onboardPosNED, onboardLat, onboardLon, onboardHgt, _ekf->latRef, _ekf->lonRef, _ekf->hgtRef);
                 }
 
@@ -1029,7 +1029,7 @@ void readAhrsData()
 
 void readFlowData()
 {
-    if (pInFlowFile <= 0)
+    if (pInFlowFile == nullptr)
         return;
 
     float temp[8];


### PR DESCRIPTION
This check against an integer is bad practice and illegal in some compilers, so code may not compile.